### PR TITLE
Add Dataset: Moving MNIST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ env
 __pycache__
 *.egg-info
 env-*
+moving_mnist_data
+frame.png
+*.prof
+logs.txt
+sequences

--- a/RecurrentFF/benchmarks/MNIST/mnist.py
+++ b/RecurrentFF/benchmarks/MNIST/mnist.py
@@ -145,7 +145,6 @@ def test_collate_fn(batch):
 
     # 3. Repeat along a new dimension for ITERATIONS times
     data = data.unsqueeze(0).repeat(ITERATIONS, 1, 1)
-    labels = labels.unsqueeze(0).repeat(ITERATIONS, 1, 1)
 
     # 4. Return as a custom object
     return TestData(data, labels)

--- a/RecurrentFF/benchmarks/Moving-MNIST/constants.py
+++ b/RecurrentFF/benchmarks/Moving-MNIST/constants.py
@@ -1,0 +1,1 @@
+MOVING_MNIST_DATA_DIR='./moving_mnist_data'

--- a/RecurrentFF/benchmarks/Moving-MNIST/dataset_generator.py
+++ b/RecurrentFF/benchmarks/Moving-MNIST/dataset_generator.py
@@ -1,0 +1,130 @@
+import logging
+import os
+import string
+import random
+
+import torch
+from torch.utils.data import DataLoader
+from torchvision.datasets import MNIST
+from torchvision.transforms import Compose, ToTensor
+
+from constants import MOVING_MNIST_DATA_DIR
+
+
+BATCH_SIZE = 1
+
+
+def get_random_string(length):
+    letters_and_digits = string.ascii_letters + string.digits
+    result_str = ''.join(random.choice(letters_and_digits)
+                         for _ in range(length))
+    return result_str
+
+
+def move_images(images, frames, velocities):
+    # Expand canvas from 28x28 to 64x64
+    extended_images = torch.zeros((images.shape[0], 64, 64))
+    extended_images[:, 18:46, 18:46] = images
+
+    # Initialize sequence tensor
+    sequence = torch.zeros((images.shape[0], frames, 64, 64))
+
+    # Set initial positions
+    # Starting at the center
+    positions = torch.full((images.shape[0], 2), 18)
+
+    for frame in range(frames):
+        # Clear old positions
+        extended_images *= 0
+        # Apply new positions
+        for i, (x, y) in enumerate(positions):
+            extended_images[i, x:x+28, y:y+28] = images[i]
+
+        sequence[:, frame] = extended_images
+
+        # Update positions
+        positions += velocities
+
+        # Reflect pixels off boundaries
+        bounce = ((positions < 0) | (positions > 36))
+        velocities[bounce] *= -1
+        positions[positions < 0] = 0
+        positions[positions > 36] = 36
+
+    return sequence
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+
+    # Pytorch utils.
+    torch.autograd.set_detect_anomaly(True)
+    torch.manual_seed(1234)
+
+    transform = Compose([
+        ToTensor(),
+    ])
+
+    # ===========================TRAIN===========================
+
+    mnist_loader = DataLoader(MNIST('./data/', train=True, download=True, transform=transform),
+                              batch_size=BATCH_SIZE, shuffle=True, num_workers=0)
+
+    # create directory for data if it doesn't exist
+    os.makedirs(MOVING_MNIST_DATA_DIR, exist_ok=True)
+
+    # Test on each batch
+    sequences_build = []
+    labels_build = []
+    for i, (images, labels) in enumerate(mnist_loader):
+        images = images.squeeze(1)  # Remove channel dimension for simplicity
+        # Random velocities
+        velocities = torch.randint(-5, 6, (images.shape[0], 2))
+        sequences = move_images(images, 50, velocities)
+
+        sequences_build.append(sequences)
+        labels_build.append(labels)
+
+        if i != 0 and i % 1000 == 0:
+            data = {'sequences': torch.cat(
+                sequences_build, dim=0), 'labels': torch.cat(labels_build, dim=0)}
+            torch.save(data, f'{MOVING_MNIST_DATA_DIR}/train_{i}.pt')
+            sequences_build.clear()
+            labels_build.clear()
+            print(f"Saved {i} train sequences")
+        elif i == len(mnist_loader) - 1:
+            data = {'sequences': torch.cat(
+                sequences_build, dim=0), 'labels': torch.cat(labels_build, dim=0)}
+            torch.save(
+                data, f'{MOVING_MNIST_DATA_DIR}/train_{len(mnist_loader)}.pt')
+
+    # ===========================TEST===========================
+
+    mnist_loader = DataLoader(MNIST('./data/', train=False, download=True, transform=transform),
+                              batch_size=BATCH_SIZE, shuffle=True, num_workers=0)
+
+    # Test on each batch
+    sequences_build = []
+    labels_build = []
+    for i, (images, labels) in enumerate(mnist_loader):
+        images = images.squeeze(1)  # Remove channel dimension for simplicity
+        # Random velocities
+        velocities = torch.randint(-5, 6, (images.shape[0], 2))
+        sequences = move_images(images, 50, velocities)
+
+        sequences_build.append(sequences)
+        labels_build.append(labels)
+
+        if i != 0 and i % 1000 == 0:
+            data = {'sequences': torch.cat(
+                sequences_build, dim=0), 'labels': torch.cat(labels_build, dim=0)}
+            torch.save(data, f'{MOVING_MNIST_DATA_DIR}/test_{i}.pt')
+            sequences_build.clear()
+            labels_build.clear()
+            print(f"Saved {i} test sequences")
+        elif i == len(mnist_loader) - 1:
+            data = {'sequences': torch.cat(
+                sequences_build, dim=0), 'labels': torch.cat(labels_build, dim=0)}
+            torch.save(
+                data, f'{MOVING_MNIST_DATA_DIR}/test_{len(mnist_loader)}.pt')

--- a/RecurrentFF/benchmarks/Moving-MNIST/moving_mnist.py
+++ b/RecurrentFF/benchmarks/Moving-MNIST/moving_mnist.py
@@ -28,6 +28,8 @@ class MovingMNISTDataset(Dataset):
     blocking. The class is designed to work with .pt files and supports
     train/test splitting based on filename prefix.
 
+    NOTE: Do not use shuffle=True for the dataloader. It is not supported.
+
     Parameters
     ----------
     root_dir : str

--- a/RecurrentFF/benchmarks/Moving-MNIST/moving_mnist.py
+++ b/RecurrentFF/benchmarks/Moving-MNIST/moving_mnist.py
@@ -1,0 +1,268 @@
+import os
+import logging
+import time
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+import wandb
+from matplotlib import pyplot as plt
+from multiprocessing import Process, Manager
+
+from RecurrentFF.model.model import RecurrentFFNet, TrainInputData, TrainLabelData, TestData
+from RecurrentFF.model.constants import EPOCHS, LEARNING_RATE, THRESHOLD, DAMPING_FACTOR, EPSILON, DEVICE
+
+NUM_CLASSES = 10
+INPUT_SIZE = 4096
+LAYERS = [1000, 1000, 1000]
+TRAIN_BATCH_SIZE = 5000
+TEST_BATCH_SIZE = 5000
+ITERATIONS = 10
+DATA_PER_FILE = 1000
+
+
+class MovingMNISTDataset(Dataset):
+    """
+    Custom Dataset class for loading and processing the Moving MNIST dataset.
+
+    The data are loaded asynchronously in a separate process to avoid I/O
+    blocking. The class is designed to work with .pt files and supports
+    train/test splitting based on filename prefix.
+
+    Parameters
+    ----------
+    root_dir : str
+        Path to the directory with .pt files.
+    train : bool, optional
+        If True, the dataset will only load files with 'train_' prefix. If
+        False, only 'test_' files are loaded.
+    queue_maxsize : int, optional
+        The maximum size of the data loading queue.
+
+    Attributes
+    ----------
+    root_dir : str
+        Path to the directory with .pt files.
+    train : bool
+        If True, the dataset will only load files with 'train_' prefix.
+    queue_maxsize : int
+        The maximum size of the data loading queue.
+    data_files : list
+        List of .pt files to be loaded.
+    file_idx : int
+        Index of the current file being processed.
+    data_chunk_idx : int
+        Index of the current chunk in memory.
+    data_queue : multiprocessing.Manager().Queue()
+        A queue object used for loading data chunks.
+    load_event : multiprocessing.Manager().Event()
+        An event object used for signaling when new data should be loaded.
+    loader_process : multiprocessing.Process()
+        A separate process for loading data chunks.
+    data_chunk : dict
+        The current data chunk in memory.
+    """
+
+    def __init__(self, root_dir, train=True, queue_maxsize=5):
+        self.root_dir = root_dir
+        self.train = train
+        self.queue_maxsize = queue_maxsize
+
+        # List of all .pt files in root_dir
+        self.data_files = [f for f in os.listdir(
+            self.root_dir) if f.endswith('.pt')]
+
+        # Separate train and test files
+        if self.train:
+            self.data_files = [
+                f for f in self.data_files if f.startswith('train_')]
+        else:
+            self.data_files = [
+                f for f in self.data_files if f.startswith('test_')]
+
+        self.file_idx = 0  # Index of the current file
+        self.data_chunk_idx = 0  # Index of the current chunk in memory
+
+        manager = Manager()
+        self.data_queue = manager.Queue(
+            maxsize=self.queue_maxsize)  # Parameterized queue size
+        self.load_event = manager.Event()
+
+        chunk_data = torch.load(os.path.join(
+            self.root_dir, self.data_files[self.file_idx]))
+        self.data_queue.put(chunk_data)
+        self.file_idx += 1
+
+        self.loader_process = Process(
+            target=self._load_data_loop, args=(self.data_queue, self.load_event))
+        self.loader_process.start()
+
+        self.data_chunk = self.data_queue.get()  # Load first chunk into memory
+
+    def __len__(self):
+        # this will be called at beginning of new batch, so reset is needed
+        self.data_chunk_idx = 0
+        return len(self.data_files) * DATA_PER_FILE
+
+    def __getitem__(self, idx):
+        """
+        Fetches a data instance and its corresponding label from the dataset.
+
+        If the requested index goes beyond the current data chunk, the method
+        signals for the next chunk to be loaded.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the data instance to fetch.
+
+        Returns
+        -------
+        tuple
+            Tuple of sequences and corresponding one-hot labels.
+        """
+        while idx >= self.data_chunk_idx + len(self.data_chunk["sequences"]):
+            self.load_event.set()  # Signal the background process to load more data
+
+            while self.data_queue.empty():
+                time.sleep(0.1)  # Wait for data to be loaded
+                pass
+
+            self.data_chunk = self.data_queue.get()  # Wait for data to be loaded
+            # Update the chunk start index
+            self.data_chunk_idx += len(self.data_chunk["sequences"])
+
+        sequences = self.data_chunk['sequences'][idx -
+                                                 self.data_chunk_idx][0:ITERATIONS]
+        sequences = sequences.view(sequences.shape[0], -1)
+
+        y_pos = self.data_chunk['labels'][idx - self.data_chunk_idx]
+        y_neg = y_pos
+        while y_neg == y_pos:
+            y_neg = torch.randint(0, NUM_CLASSES, (1,)).item()
+
+        positive_one_hot_labels = torch.zeros(NUM_CLASSES)
+        positive_one_hot_labels[y_pos] = 1.0
+
+        negative_one_hot_labels = torch.zeros(NUM_CLASSES)
+        negative_one_hot_labels[y_neg] = 1.0
+
+        return (sequences, sequences), (positive_one_hot_labels, negative_one_hot_labels)
+
+    def _load_data_loop(self, data_queue, load_event):
+        """
+        An internal method that runs in a separate process and loads data
+        chunks.
+
+        The method waits for a load event before loading data. It then loads as
+        many chunks as it can into the queue.
+
+        Parameters
+        ----------
+        data_queue : multiprocessing.Manager().Queue()
+            The queue to which data chunks are loaded.
+        load_event : multiprocessing.Manager().Event()
+            An event object used for signaling when new data should be loaded.
+        """
+        while True:
+            load_event.wait()  # Wait for a signal to load data
+
+            # Load chunks into the queue until it is full or all data files have been loaded
+            while not data_queue.full() and self.file_idx < len(self.data_files):
+                chunk_data = torch.load(os.path.join(
+                    self.root_dir, self.data_files[self.file_idx]))
+                data_queue.put(chunk_data)
+                self.file_idx += 1
+
+            load_event.clear()  # Clear the event after data is loaded
+
+            # reset the loop
+            if self.file_idx >= len(self.data_files):
+                self.file_idx = 0
+
+
+def train_collate_fn(batch):
+    data_batch, label_batch = zip(*batch)
+
+    data1, data2 = zip(*data_batch)
+    positive_labels, negative_labels = zip(*label_batch)
+
+    data1 = torch.stack(data1, 1)
+    data2 = torch.stack(data2, 1)
+    positive_labels = torch.stack(positive_labels)
+    negative_labels = torch.stack(negative_labels)
+
+    positive_labels = positive_labels.unsqueeze(0).repeat(ITERATIONS, 1, 1)
+    negative_labels = negative_labels.unsqueeze(0).repeat(ITERATIONS, 1, 1)
+
+    return TrainInputData(data1, data2), TrainLabelData(positive_labels, negative_labels)
+
+
+def test_collate_fn(batch):
+    data_batch, label_batch = zip(*batch)
+
+    pos_data, _neg_data = zip(*data_batch)
+    positive_labels, _negative_labels = zip(*label_batch)
+
+    pos_data = torch.stack(pos_data, 1)
+    positive_labels = torch.stack(positive_labels)
+
+    positive_labels = positive_labels.argmax(dim=1)
+
+    return TestData(pos_data, positive_labels)
+
+
+def MNIST_loaders(train_batch_size, test_batch_size):
+    # TODO: need a transform? Similar to MNIST:
+    # transform = Compose([
+    #     ToTensor(),
+    #     Normalize((0.1307,), (0.3081,)),
+    #     Lambda(lambda x: torch.flatten(x))])
+
+    # Cannot shuffle with the dataset implementation
+    train_loader = DataLoader(MovingMNISTDataset('{MOVING_MNIST_DATA_DIR}/', train=True),
+                              batch_size=train_batch_size, shuffle=False, collate_fn=train_collate_fn, num_workers=0)
+
+    test_loader = DataLoader(MovingMNISTDataset('{MOVING_MNIST_DATA_DIR}/', train=False),
+                             batch_size=test_batch_size, shuffle=False, collate_fn=test_collate_fn, num_workers=0)
+
+    return train_loader, test_loader
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+
+    # Pytorch utils.
+    torch.autograd.set_detect_anomaly(True)
+    torch.manual_seed(1234)
+
+    print("init wandb")
+    wandb.init(
+        # set the wandb project where this run will be logged
+        project="Recurrent-FF",
+
+        # track hyperparameters and run metadata
+        config={
+            "architecture": "Recurrent-FF",
+            "dataset": "Moving-MNIST",
+            "epochs": EPOCHS,
+            "learning_rate": LEARNING_RATE,
+            "layers": str(LAYERS),
+            "iterations": ITERATIONS,
+            "threshold": THRESHOLD,
+            "damping_factor": DAMPING_FACTOR,
+            "epsilon": EPSILON,
+        }
+    )
+
+    # Generate train data.
+    train_loader, test_loader = MNIST_loaders(
+        TRAIN_BATCH_SIZE, TEST_BATCH_SIZE)
+
+    # Create and run model.
+    model = RecurrentFFNet(TRAIN_BATCH_SIZE, TEST_BATCH_SIZE,
+                           INPUT_SIZE, LAYERS, NUM_CLASSES).to(DEVICE)
+
+    model.train(train_loader, test_loader)
+
+    model.predict(test_loader)

--- a/RecurrentFF/benchmarks/Seq-MNIST/seq.py
+++ b/RecurrentFF/benchmarks/Seq-MNIST/seq.py
@@ -197,13 +197,10 @@ class SeqMnistTestDataset(Dataset):
 
         # separate label and data
         one_hot_label = torch.Tensor(data[0, :10])
-        y = one_hot_label.argmax().item()  # Convert one-hot label to scalar
+        y = one_hot_label.argmax()  # Convert one-hot label to scalar
 
         if self.transform:
             x = self.transform(x)
-
-        # expand y to have shape (iterations)
-        y = torch.full((x.shape[0],), y)
 
         return x, y
 
@@ -246,7 +243,7 @@ def collate_test(batch):
     """
     data, labels = zip(*batch)
     data = torch.stack(data).transpose(0, 1)
-    labels = torch.stack(labels).transpose(0, 1)
+    labels = torch.stack(labels)
 
     return TestData(data, labels)
 

--- a/RecurrentFF/benchmarks/Seq-MNIST/seq.py
+++ b/RecurrentFF/benchmarks/Seq-MNIST/seq.py
@@ -1,8 +1,6 @@
 import logging
 import os
-import tarfile
 from io import BytesIO
-import random
 
 import torch
 import torch.nn.functional as F

--- a/RecurrentFF/model/constants.py
+++ b/RecurrentFF/model/constants.py
@@ -6,4 +6,5 @@ THRESHOLD = 1
 DAMPING_FACTOR = 0.7
 EPSILON = 1e-8
 LEARNING_RATE = 0.00005
-DEVICE = torch.device("cuda")
+DEVICE = torch.device("mps")
+SKIP_PROFILING = 1

--- a/RecurrentFF/model/model.py
+++ b/RecurrentFF/model/model.py
@@ -7,7 +7,10 @@ from torch.nn import functional as F
 from torch.optim import Adam
 import wandb
 
-from RecurrentFF.model.constants import EPSILON, DAMPING_FACTOR, LEARNING_RATE, EPOCHS, THRESHOLD, DEVICE
+from RecurrentFF.model.constants import EPSILON, DAMPING_FACTOR, LEARNING_RATE, EPOCHS, THRESHOLD, DEVICE, SKIP_PROFILING
+
+from profilehooks import profile
+
 
 # TODO:
 # 1 - Experiment with weight initialization
@@ -30,6 +33,7 @@ def standardize_layer_activations(layer_activations):
     return prev_layer_stdized
 
 
+# input of dims (frames, batch size, input size)
 class TrainInputData:
     def __init__(self, pos_input, neg_input):
         self.pos_input = pos_input
@@ -44,6 +48,7 @@ class TrainInputData:
         self.neg_input = self.neg_input.to(device)
 
 
+# input of dims (frames, batch size, num classes)
 class TrainLabelData:
     def __init__(self, pos_labels, neg_labels):
         self.pos_labels = pos_labels
@@ -58,10 +63,10 @@ class TrainLabelData:
         self.neg_labels = self.neg_labels.to(device)
 
 
+# input of dims (batch size, num classes)
 class TestData:
     def __init__(self, input, labels):
         self.input = input
-        # TODO: this should not be a one-hot vector, as it precludes multiclass classification
         self.labels = labels
 
     def __iter__(self):
@@ -182,11 +187,11 @@ class RecurrentFFNet(nn.Module):
     architecture.
     """
 
-    def __init__(self, train_batch_size, test_batch_size, input_size, hidden_sizes, num_classes, damping_factor=DAMPING_FACTOR, changing_classes=False):
+    def __init__(self, train_batch_size, test_batch_size, input_size, hidden_sizes, num_classes, damping_factor=DAMPING_FACTOR, static_singleclass=True):
         logging.info("initializing network")
         super(RecurrentFFNet, self).__init__()
 
-        self.changing_classes = changing_classes
+        self.static_singleclass = static_singleclass
         self.num_classes = num_classes
         self.layers = nn.ModuleList()
         prev_size = input_size
@@ -217,6 +222,7 @@ class RecurrentFFNet(nn.Module):
         for layer in self.layers:
             layer.reset_activations(isTraining)
 
+    @profile(stdout=False, filename='baseline.prof', skip=SKIP_PROFILING)
     def train(self, train_loader, test_loader):
         """
         Trains the RecurrentFFNet model using the provided train and test data loaders.
@@ -244,6 +250,7 @@ class RecurrentFFNet(nn.Module):
             layer's activations into a 'goodness' score. This function operates on the RecurrentFFNet model level
             and is called during the training process.
         """
+
         for epoch in range(0, EPOCHS):
             logging.info("Epoch: " + str(epoch))
 
@@ -301,9 +308,11 @@ class RecurrentFFNet(nn.Module):
                     # No-op as there may not be 3 layers
                     pass
 
+                logging.debug("getting next batch")
+
             # Get some observability into prediction while training. We cannot
             # use this if the dataset doesn't have static classes.
-            if self.changing_classes == False:
+            if self.static_singleclass == True:
                 accuracy = self.brute_force_predict_for_static_class_scenario(
                     test_loader, 1)
 
@@ -370,8 +379,9 @@ class RecurrentFFNet(nn.Module):
 
                 iterations = data.shape[0]
 
+                # TODO FIX: this fixes moving mnist but regresses mnist
                 # exploit the fact we know this is a static class scenario
-                labels = labels[0]
+                # labels = labels[0]
 
                 all_labels_goodness = []
 

--- a/RecurrentFF/model/model.py
+++ b/RecurrentFF/model/model.py
@@ -379,10 +379,6 @@ class RecurrentFFNet(nn.Module):
 
                 iterations = data.shape[0]
 
-                # TODO FIX: this fixes moving mnist but regresses mnist
-                # exploit the fact we know this is a static class scenario
-                # labels = labels[0]
-
                 all_labels_goodness = []
 
                 # evaluate goodness for each possible label


### PR DESCRIPTION
Bench looks comparable to regular MNIST. Dark orange is Moving MNIST.

![image](https://github.com/and-rewsmith/RecurrentForwardForward/assets/19913741/6ff11f00-4e7c-4788-ad5a-7f4150fef36f)


Changes:
1. Added profiling to the model
2. Code to generate dataset for Moving MNIST
3. Code to run Moving MNIST model

3 was a bit tricky. The dataloader was suffering from too much disk I/O, which was grinding model execution speed to a halt. I implemented a multiprocess background loader to get around this.